### PR TITLE
refactor WithPreProcessor and WithPostProcessor to return *Builder in…

### DIFF
--- a/pkg/transactions/transactions.go
+++ b/pkg/transactions/transactions.go
@@ -478,16 +478,16 @@ func Run(ctx context.Context, opt ...options.Option) (*dynamodb.TransactWriteIte
 	return builder.Run(ctx, t.db)
 }
 
-func WithPreProcessor(ctx context.Context, f func(*Builder)) context.Context {
+func WithPreProcessor(ctx context.Context, f func(*Builder)) *Builder {
 	if t, ok := From(ctx); ok {
-		t.WithPreProcessor(f)
+		return t.WithPreProcessor(f)
 	}
-	return ctx
+	return nil
 }
 
-func WithPostProcessor(ctx context.Context, f func(*Builder, error)) context.Context {
+func WithPostProcessor(ctx context.Context, f func(*Builder, error)) *Builder {
 	if t, ok := From(ctx); ok {
-		t.WithPostProcessor(f)
+		return t.WithPostProcessor(f)
 	}
-	return ctx
+	return nil
 }


### PR DESCRIPTION
This pull request modifies the `WithPreProcessor` and `WithPostProcessor` functions in `pkg/transactions/transactions.go` to return a `*Builder` instead of a `context.Context`. This change improves type clarity and ensures the functions return the specific object being processed, rather than the broader context.

Key changes to function signatures:

* [`pkg/transactions/transactions.go`](diffhunk://#diff-93d2f6b9ba24f7cdc07aae3fb18aa6267e01fb82804a8a487a0c530737f30c1aL481-R492): Updated the `WithPreProcessor` function to return a `*Builder` instead of `context.Context`. If the `Builder` is not found in the context, it now returns `nil`.
* [`pkg/transactions/transactions.go`](diffhunk://#diff-93d2f6b9ba24f7cdc07aae3fb18aa6267e01fb82804a8a487a0c530737f30c1aL481-R492): Updated the `WithPostProcessor` function to return a `*Builder` instead of `context.Context`. Similar to the `WithPreProcessor` function, it returns `nil` if the `Builder` is not found.…stead of context.Context